### PR TITLE
[Update]企業topページ・各レイアウト・部分テンプレート化[Fix]companyの検索機能

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -9,14 +9,16 @@ class Admin::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    super
+    flash[:notice] = "ログインしました"
+  end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+    flash[:notice] = "ログアウトしました"
+  end
 
   # protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,24 +4,21 @@ class ApplicationController < ActionController::Base
    def after_sign_in_path_for(resource)
      case resource
      when Admin
-       flash[:notice] = "ログインに成功しました"
        admin_root_path
      when Company
-       company_path(@company.id)
+       top_path(@company.id)
      when Employee
-       flash[:notice] = "ログインに成功しました"
        mypage_path(@employee.id)
      end
    end
 
    def after_sign_out_path_for(resource_or_scope)
     if resource_or_scope == :company
-     new_company_session_path
+     root_path
     elsif resource_or_scope == :admin
      new_admin_session_path
     elsif resource_or_scope == :employee
-     flash[:alert] = "ログアウトしました"
-     new_employee_session_path
+     root_path
     else
      root_path
     end

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,5 +1,8 @@
 class Public::HomesController < ApplicationController
   def top
-    
+    @company = current_company
+    @recent_posts = Post.where(company_id: @company.id).group(:employee_id).order(created_at: :desc) #最近の投稿
+    @all_posts_count_by_employee = @company.posts.group(:employee_id).count #社員１人が投稿した全件数
+    @favorites_count_by_employee = Post.joins(:favorites).where(company_id: @company.id).group(:employee_id).count
   end
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -26,7 +26,7 @@ class Public::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
-  
-  
+
+
 
 end

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -9,14 +9,16 @@ class User::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    super
+    flash[:notice] = "ログインしました。"
+  end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+    flash[:notice] = "ログアウトしました"
+  end
 
   protected
 
@@ -24,12 +26,12 @@ class User::SessionsController < Devise::SessionsController
    devise_parameter_sanitizer.permit(:sign_in) do |user_params|
     user_params.permit(:email, :password, :password_confirmation)
    end
-  end 
-  
-  
+  end
+
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
-  
+
 end

--- a/app/views/admin/posts/history.html.erb
+++ b/app/views/admin/posts/history.html.erb
@@ -24,7 +24,7 @@
                 <span class="sr-only">次へ</span>
               </a>
             </div>
-          <% elsif posts.video.attached? %>
+          <% elsif post.video.attached? %>
             <div class='file-container'>
               <%= video_tag rails_blob_url(post.video), controls: true, class: 'responsive-video rounded', width: '100%', height: '250' %>
             </div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,27 +1,10 @@
 <div class="card jumbotron">
   <div class="row">
-    <div class="col-7">
-      <div class="admin-heading col-7">
-        <h4><%= @company.company_name %>様の投稿履歴一覧</h4>
-      </div>
-      <div class="col-8"></div>
-    </div>
+    <%= render partial: 'shared/admin_heading' %>
     <div class="col-12 mx-auto">
       <%= link_to '企業投稿一覧へ', admin_top_path, class: "btn btn-outline-primary" %>
       <table class="table table_border">
-        <thead class="thead-light">
-          <div class="row table-row">
-            <div class="col-8 mx-auto">
-              <tr>
-                <th>投稿者</th>
-                <th>最近の投稿件数</th>
-                <th>投稿全件数</th>
-                <th>いいね全件数</th>
-                <th></th>
-              </tr>
-            </div>
-          </div>
-        </thead>
+        <%= render partial: 'shared/table_header' %>
         <tbody>
         <% @recent_posts.each do |post| %>
           <tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,9 @@
              <i class="fa-solid fa-layer-group"></i> 管理
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+             <%= link_to top_path(current_company), class: 'dropdown-item' do %>
+             <i class="fa-solid fa-clock-rotate-left"></i> 投稿履歴管理
+             <% end %>
              <a class="dropdown-item" href="/companies/posts/index"><i class="fa-regular fa-image"></i> 投稿管理</a>
              <a class="dropdown-item" href="/stores"><i class="fa-solid fa-shop"></i> 店舗管理</a>
              <a class="dropdown-item" href="/car_names"><i class="fa-solid fa-car"></i> 車両管理</a>
@@ -90,7 +93,7 @@
           </li>
           <li class="nav-item dropdown">
              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-               Dropdown
+               カテゴリー
              </a>
            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
              <a class="dropdown-item" href="/posts/new"><i class="fa-regular fa-square-plus"></i> New Post</a>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,24 +1,19 @@
-<div class="container">
+<div class="card jumbotron">
   <div class="row">
-    <div class="col-7">
-  　　<div class="admin-heading col-7">
-    　　<h4>投稿履歴一覧</h4>
-  　　</div>
-  　　<div class="col-8"></div>
-　　</div>
+    <%= render partial: 'shared/admin_heading' %>
     <div class="col-12 mx-auto">
-      <table class="table table-hover rounded-top rounded-bottom table_border_radius admin-order-table">
-        <thead class="thead-dark">
-          <div class="row table-row">
-           <div class="col-8 mx-auto">
-            <table class="table">
-             <thead class="thead-light">
-              <tr>        
-                <th>投稿日時</th>
-                <th>投稿者</th>
-                <th>投稿内容</th>
-              </tr>
-        </thead>
+      <table class="table table_border">
+        <%= render partial: 'shared/table_header' %>
+        <tbody>
+        <% @recent_posts.each do |post| %>
+          <tr>
+            <td><%= link_to post.employee.full_name, public_show_post_path(id: post.id) %></td>
+            <td><%= post.recent_post_count %>件</td>
+            <td><%= @all_posts_count_by_employee[post.employee_id] %>件</td>
+            <td><%= @favorites_count_by_employee[post.employee_id].to_i.zero? ? 0 : @favorites_count_by_employee[post.employee_id] %>件</td>
+          </tr>
+        <% end %>
+        </tbody>
       </table>
     </div>
   </div>

--- a/app/views/searches/_post.html.erb
+++ b/app/views/searches/_post.html.erb
@@ -15,7 +15,7 @@
     <% if admin_signed_in? %>
       <%= link_to '投稿詳細', admin_company_employee_post_path(company_id: post.company_id, id: post.id, employee_id: post.employee_id), method: :get, class: "btn btn-outline-primary" %>
     <% elsif company_signed_in? %>
-      <%= link_to '投稿詳細', class: "btn btn-outline-primary" %>
+      <%= link_to '投稿詳細', public_show_post_path(id: post.id), class: "btn btn-outline-primary" %>
     <% elsif employee_signed_in? %>
       <%= link_to '投稿詳細', post_path(post), class: "btn btn-outline-primary" %>
     <% end %>

--- a/app/views/searches/search.html.erb
+++ b/app/views/searches/search.html.erb
@@ -25,7 +25,7 @@
     <% else %>
       <!--検索対象モデルがUserではない時(= 検索対象モデルがPostの時) -->
       <tbody>
-        <%= render partial: 'post', collection: @posts.select { |post| post.employee.company_id == current_company.company_id } %>
+        <%= render partial: 'post', collection: @posts.select { |post| post.company.employee_ids == current_company.employee_ids } %>
       </tbody>
     <% end %>
   </table>

--- a/app/views/shared/_admin_heading.html.erb
+++ b/app/views/shared/_admin_heading.html.erb
@@ -1,0 +1,5 @@
+<div class="col-7">
+  <div class="admin-heading col-7">
+    <h4><%= @company.company_name %>様の投稿履歴一覧</h4>
+  </div>
+</div>

--- a/app/views/shared/_table_header.html.erb
+++ b/app/views/shared/_table_header.html.erb
@@ -1,0 +1,13 @@
+<thead class="thead-light">
+  <div class="row table-row">
+    <div class="col-8 mx-auto">
+      <tr>
+        <th>投稿者</th>
+        <th>最近の投稿件数</th>
+        <th>投稿全件数</th>
+        <th>いいね全件数</th>
+        <th></th>
+      </tr>
+    </div>
+  </div>
+</thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,13 +79,12 @@ Rails.application.routes.draw do
             get "unsubscribe"
             patch "withdraw"
         end
-
-
       resources :tasks
       resources :daily_tasks, only: [:new, :create]
     end
 
    resources :employees, only: [:create, :index, :show, :edit, :update] do
+
      resources :tasks, only: [:show]
    end
    patch 'companies/employees/:id' => 'employees#update', as: 'public_update_employee'


### PR DESCRIPTION
app/controllers/admin/sessions_controller.rb
app/controllers/user/sessions_controller.rb
-フラッシュメッセージが重複していたので修正

app/controllers/application_controller.rb
-フラッシュメッセージの修正
-ログイン時ログアウト時の遷移先変更
log_in
company→top

log_out
company・employee→root_path

app/controllers/public/homes_controller.rb
app/views/admin/posts/index.html.erb
app/views/public/homes/top.html.erb
app/views/shared/_admin_heading.html.erb
app/views/shared/_table_header.html.erb
企業のトップ画面に投稿履歴が表示するように実装
また、adminと記述が類似しているので部分テンプレート化

app/views/admin/posts/history.html.erb
エラーが出ていたので修正

app/views/layouts/application.html.erb
企業のnav-linkに投稿履歴管理を配置

app/views/searches/_post.html.erb
app/views/searches/search.html.erb
エラーが出ていたので修正