### PR TITLE
[Update] 企業、社員のis_active(true or  false)の状態による制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,23 @@ class ApplicationController < ActionController::Base
   def test
     @company = Company.find(params[:company_id]) if params[:company_id] && controller_name == 'admin/posts' && action_name == 'index'
   end
+
+  private
+
+  def authenticate_employee!
+    if !(current_employee && current_employee.is_active?)
+      flash[:alert] = "failed"
+      sign_out(current_employee)
+      redirect_to root_url
+    end
+  end
+
+  def authenticate_company!
+    if !(current_company && current_company.is_active?)
+      flash[:alert] = "failed"
+      sign_out(current_company)
+      redirect_to root_url
+    end
+  end
+
 end

--- a/app/controllers/company/companies_controller.rb
+++ b/app/controllers/company/companies_controller.rb
@@ -41,6 +41,13 @@ class Company::CompaniesController < ApplicationController
     end
   end
 
+  def authenticate_company!
+    if !(current_employee && current_employee.is_active?)
+      flash[:alert] = "failed"
+      redirect_to root_url
+    end
+  end
+
   def company_params
     params.require(:company).permit(:email, :company_name, :company_name_kana, :address, :postal_code, :phone_number, :password, :password_confirmation,)
   end

--- a/app/controllers/employee/daily_tasks_controller.rb
+++ b/app/controllers/employee/daily_tasks_controller.rb
@@ -33,5 +33,5 @@ class Employee::DailyTasksController < ApplicationController
   def daily_task_params
     params.require(:daily_task).permit(:employee_id, :task_id, :start_time)
   end
-  
+
 end

--- a/app/controllers/employee/favorites_controller.rb
+++ b/app/controllers/employee/favorites_controller.rb
@@ -1,5 +1,6 @@
 class Employee::FavoritesController < ApplicationController
-
+  before_action :authenticate_employee!
+  
   def create
     @post = Post.find(params[:post_id])
     current_employee.favorites.find_or_create_by(post_id: @post.id)

--- a/app/controllers/employee/homes_controller.rb
+++ b/app/controllers/employee/homes_controller.rb
@@ -1,4 +1,5 @@
 class Employee::HomesController < ApplicationController
+  
   def top
     if current_employee
       @company = current_employee.company

--- a/app/controllers/employee/likes_controller.rb
+++ b/app/controllers/employee/likes_controller.rb
@@ -1,5 +1,6 @@
 class Employee::LikesController < ApplicationController
-
+  before_action :authenticate_employee!
+  
   def create
     @post_comment = PostComment.find(params[:post_comment_id])
     puts "@post_comment: #{@post_comment.inspect}"

--- a/app/controllers/employee/post_comments_controller.rb
+++ b/app/controllers/employee/post_comments_controller.rb
@@ -1,5 +1,7 @@
 class Employee::PostCommentsController < ApplicationController
-
+  before_action :authenticate_employee!
+  before_action :correct_employee, only: [:destroy]
+  
   def create
     post = Post.find(params[:post_id])
     comment = current_employee.post_comments.new(post_comment_params)
@@ -28,6 +30,10 @@ class Employee::PostCommentsController < ApplicationController
 
   def post_comment_params
     params.require(:post_comment).permit(:comment)
+  end
+  
+  def correct_employee
+    @post_comment = current_employee.post_comments.find_by(id: params[:id])
   end
 
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -31,9 +31,7 @@ class Employee < ApplicationRecord
     company.company_name if company.present?
   end
 
-  def active_for_authentication?
-    super && (is_active?)
-  end
+  scope :only_active, -> { where(is_active: true) }
 
 
   def self.guest

--- a/app/views/employee/likes/_like.html.erb
+++ b/app/views/employee/likes/_like.html.erb
@@ -1,9 +1,9 @@
 <% if post_comment.liked_by?(current_employee) %>
    <%= link_to post_post_comment_likes_path(post_id: @post.id, post_comment_id: post_comment.id), class: 'btn btn-outline-warning btn-sm', method: :delete, remote: true do %>
      <i class="fa-solid fa-thumbs-up" aria-hidden="true" style="color: orange;"></i><%= post_comment.likes.count %>
-   <% end %>
+   <% end %></br>
 <% else %>
   <%= link_to post_post_comment_likes_path(post_id: @post.id, post_comment_id: post_comment.id) , class: 'btn btn-outline-warning btn-sm ', method: :post, remote: true do %>
     <i class="fa-regular fa-thumbs-up" aria-hidden="true"></i><%= post_comment.likes.count %>
-  <% end %>
+  <% end %></br>
 <% end %>


### PR DESCRIPTION
## is_active
- is_acutiveがtrueもしくはfalseの時の表示制限をしました。（企業から社員を退職(false)にした時に、その社員の画面で操作を不可にしサインアウトさせroot_pathに遷移するように実装しました。企業の退会も同じように実装）