### PR TITLE
[Fix] post/showからpost/index遷移時のURL, [Update] RSpec

### DIFF
--- a/app/views/shared/_post_show.html.erb
+++ b/app/views/shared/_post_show.html.erb
@@ -108,7 +108,7 @@
 
         <% else employee_signed_in? %>
 
-          <%= link_to posts_path(post.id), class: "btn btn-outline-primary" do %>
+          <%= link_to posts_path, class: "btn btn-outline-primary" do %>
            <i class="fa-solid fa-photo-film"></i> 一覧
           <% end %>
 

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -10,8 +10,13 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password { 'password' }
     password_confirmation { 'password' }
-    is_active { true }
+    is_active { [true, false] }
     company
     store
+    after(:build) do |employee|
+      employee.define_singleton_method(:full_name) do
+        "#{last_name} #{first_name}"
+      end
+    end
   end
 end


### PR DESCRIPTION
### 社員の投稿一覧URL
- 投稿詳細から投稿一覧へ遷移するとURLが/post.idとなっていた為、修正しました。

### RSpec
- 社員の一覧、詳細、編集画面のテストを追加しました。