### PR TITLE
RSpec [Fix] 企業新規登録, [Update] 企業ログイン後のテスト, [Add] 社員パスワード変更画面

### DIFF
--- a/spec/system/01_before_login_spec.rb
+++ b/spec/system/01_before_login_spec.rb
@@ -140,9 +140,9 @@ describe '[STEP1] ログイン前のテスト' do
     context '新規登録成功のテスト' do
       # let!(:company) { create(:company) }
       before do
-        fill_in 'company[company_name]', with: Faker::Lorem.characters(number: 10)
-        fill_in 'company[company_name_kana]', with: Faker::Lorem.characters(number: 10)
-        fill_in 'company[postal_code]', with: Faker::Address.zip_code
+        fill_in 'company[company_name]', with: Faker::Company.name[0, rand(3..10)]
+        fill_in 'company[company_name_kana]', with: Gimei.last.katakana[0, rand(3..10)]
+        fill_in 'company[postal_code]', with: 7.times.map { rand(0..9) }.join("")
         fill_in 'company[address]', with: Faker::Address.full_address
         fill_in 'company[phone_number]', with: Faker::PhoneNumber.phone_number
         fill_in 'company[email]', with: Faker::Internet.email
@@ -151,7 +151,7 @@ describe '[STEP1] ログイン前のテスト' do
       end
 
       it '正しく新規登録される' do
-        expect { click_button '登録' }.to change{Company.count}.by(1)
+        expect { click_button '登録' }.to (change{Company.count}).by(1)
       end
       it '新規登録後のリダイレクト先が、新規登録できた企業の詳細画面になっている' do
         click_button '登録'

--- a/spec/system/02_after_login_spec.rb
+++ b/spec/system/02_after_login_spec.rb
@@ -15,7 +15,6 @@ describe '[STEP2] 企業ログイン後のテスト' do
   let!(:post) { create(:post, company: company, employee: employee, car_name: car_name) }
 
   before do
-    # sign_in company
     visit new_company_session_path
     fill_in 'company[email]', with: company.email
     fill_in 'company[password]', with: company.password
@@ -99,7 +98,7 @@ describe '[STEP2] 企業ログイン後のテスト' do
         expect(page).to have_field 'employee[store_id]'
       end
       it 'プロフィール画像の選択が表示される' do
-
+        expect(page).to have_selector("img")
       end
       it 'last_nameフォームが表示される' do
         expect(page).to have_field 'employee[last_name]'

--- a/spec/system/03_after_employee_login_spec.rb
+++ b/spec/system/03_after_employee_login_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 describe '[STEP3] 社員ログイン後のテスト' do
-  let!(:employee) { create(:employee) }
-  #let!(:post) { create(:post, company: company, employee: employee, car_name: car_name) }
+  let(:company) { create(:company) }
+  let!(:car_name) { create(:car_name, company: company) }
+  let!(:store) { create(:store, company: company) }
+  let!(:genre) { create(:genre, company: company) }
+  let!(:employee) { create(:employee, company: company) }
+  let!(:post) { create(:post, company: company, employee: employee, car_name: car_name, store: store, genre: genre) }
 
   before do
     visit new_employee_session_path
@@ -101,6 +105,7 @@ describe '[STEP3] 社員ログイン後のテスト' do
     before do
       visit edit_mypage_path
     end
+
     context '表示内容の確認' do
       it 'URLが正しい' do
         expect(current_path).to eq '/employees/mypage/edit'
@@ -148,7 +153,7 @@ describe '[STEP3] 社員ログイン後のテスト' do
         fill_in 'employee[email]', with: Faker::Internet.email
         find(:xpath, all('button')[2].path).click
       end
-      
+
       it 'last_nameが正しく更新される' do
         expect(employee.reload.last_name).not_to eq @employee_old_last_name
       end
@@ -166,6 +171,47 @@ describe '[STEP3] 社員ログイン後のテスト' do
       end
       it 'リダイレクト先が、更新したマイページ画面になっている' do
         expect(current_path).to eq mypage_path
+      end
+    end
+  end
+
+  describe 'パスワード変更画面のテスト' do
+    before do
+      visit edit_employee_registration_path
+    end
+
+    context '表示内容の確認' do
+      it 'URLが正しい' do
+        expect(current_path).to eq '/employees/edit'
+      end
+      it 'メールアドレスが正しく表示されること' do
+        expect(page).to have_field('employee_email')
+      end
+      it '現在のパスワード入力フォームが表示されること' do
+        expect(page).to have_field('employee_current_password')
+      end
+      it '新しいパスワード入力フォームが表示されること' do
+        expect(page).to have_field('employee_password')
+      end
+      it '確認用パスワード入力フォームが表示されること' do
+        expect(page).to have_field('employee_password_confirmation')
+      end
+      it "変更ボタン（パスワード）のリンク先が正しい" do
+        expect(page).to have_link '', href: employee_registration_path
+      end
+    end
+
+     context '社員パスワード変更のテスト' do
+      before do
+        employee = FactoryBot.create(:employee)
+        fill_in 'employee[current_password]', with: employee.password
+        fill_in 'employee[password]', with: Faker::Internet.password(min_length: 6)
+        fill_in 'employee[password_confirmation]', with: Faker::Internet.password(min_length: 6)
+        click_button '変更する'
+      end
+
+      it 'パスワードがが正しく更新される' do
+        expect(employee.reload.password).not_to eq current_path
       end
     end
   end


### PR DESCRIPTION
### spec/system/01_before_login_spec.rb
- 企業新規登録時テストがうまくいかず、記述修正しました。

### spec/system/02_after_login_spec.rb
- プロフィール画像記述が抜けていたため記述しました。

### spec/system/03_after_employee_login_spec.rb
- パスワード変更画面テストの追加しました。